### PR TITLE
[issues/36] auto-approve dependabot / renovate bot

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,12 @@
+name: Auto approve
+
+on: pull_request
+
+jobs:
+  auto-approve:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: hmarr/auto-approve-action@v2.0.0
+        if: github.actor == 'renovate[bot]'


### PR DESCRIPTION
- [x] add auto-approve
fixes #36

removed:
[ ] only auto-approve when all workflows pass
and transferd into own issue #41 